### PR TITLE
Add support for splitting by back slash

### DIFF
--- a/src/Rhythm.Core/Enums/StringSplitDelimiters.cs
+++ b/src/Rhythm.Core/Enums/StringSplitDelimiters.cs
@@ -35,8 +35,12 @@
         /// <summary>
         /// Split by equals signs.
         /// </summary>
-        Equals
+        Equals,
 
+        /// <summary>
+        /// Split by \.
+        /// </summary>
+        BackSlash,
     }
 
 }

--- a/src/Rhythm.Core/StringExtensionMethods.cs
+++ b/src/Rhythm.Core/StringExtensionMethods.cs
@@ -104,6 +104,8 @@
                     return CleanItems(SplitByChars(source, '\t'));
                 case StringSplitDelimiters.Equals:
                     return CleanItems(SplitByChars(source, '='));
+                case StringSplitDelimiters.BackSlash:
+                    return CleanItems(SplitByChars(source, '\\'));
                 default:
                     return new[] { source };
             }


### PR DESCRIPTION
This PR adds splitting by back slash, "\\", to SplitBy's functionality.